### PR TITLE
hotfix: Update application.rb default locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module SAPEC
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.available_locales = [:en, :es]
-    config.i18n.default_locales = :en
+    config.i18n.default_locale = :en
     #config.i18n.fallbacks = true
   end
 end


### PR DESCRIPTION
# Description
What did you implemented/Why did you implemented this:
 - Update the application.rb file in the config folder at line 28 because of a typo that caused an error for the I18n configuration.
 
 
