### PR TITLE
Feature#82 create logic for resupplies product

### DIFF
--- a/app/controllers/resupplies_controller.rb
+++ b/app/controllers/resupplies_controller.rb
@@ -1,0 +1,49 @@
+class ResuppliesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_resupply, only: [:edit]
+
+  def index
+    @resupplies = Resupply.all
+    @Product = Product.all
+  end
+
+  def new 
+    @resupply = Resupply.new
+    $product_url = params[:product_id]
+  end
+
+  def create
+    @resupply = Resupply.new(resupply_params)
+      if @resupply.save
+        update_product
+        redirect_to products_url
+      else
+        render :new, status: :unprocessable_entity
+      end
+  end
+
+  def show;end
+
+  def edit;end
+
+  def update_product
+    @product = Product.find_by(id: $product_url)
+    new_stock = @product.stock + @resupply.quantity
+    @product.update(stock: new_stock)
+  end
+
+  private 
+
+  def request_url
+    @query = request.query_parameters
+  end
+
+  def resupply_params
+    params.require(:resupply).permit(
+      :product_id,
+      :quantity,
+      :comment
+    )
+  end
+
+end

--- a/app/models/product_resupplie.rb
+++ b/app/models/product_resupplie.rb
@@ -1,0 +1,4 @@
+class ProductResupplie < ApplicationRecord
+    belongs_to :product
+    belongs_to :resupply
+end

--- a/app/models/resupply.rb
+++ b/app/models/resupply.rb
@@ -1,0 +1,4 @@
+class Resupply < ApplicationRecord
+  has_many :products
+  validates :quantity, presence: true, numericality: true
+end

--- a/app/views/products/partials/_products_table.html.erb
+++ b/app/views/products/partials/_products_table.html.erb
@@ -53,18 +53,28 @@
                 <td class="text-sm text-gray-900 font-normal px-2 py-4 whitespace-nowrap ">
                   <%= product.stock %>
                 </td>
+<<<<<<< HEAD
+                <td class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap ">
+                    <%= link_to "Show this product", product, class: "bg-blue-600 hover:bg-blue-400 text-white font-bold py-2 px-4 rounded-full" %>
+                </td>
+                <td scope="col" class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap">
+                    <%= button_to 'Remove', product_path(product), method: :delete, class: 'bg-red-600 hover:bg-red-500 text-white font-bold py-2 px-4 rounded-full', form: { data: { turbo_confirm: 'Are you sure?' } } %>
+=======
                 <td class=" text-center text-sm text-gray-900 font-normal py-4 max-w-[100px]">
                   <div class="flex justify-center space-x-2">
                     <%= link_to 'Edit',
                       edit_product_path(product),
                       class: 'bg-blue-500 text-white font-bold py-2 px-6 rounded-full hover:bg-blue-600' %>
-
+                       <%= link_to 'Resupply',
+                      new_resupply_path(:product_id => product),
+                      class: 'bg-blue-500 text-white font-bold py-2 px-6 rounded-full hover:bg-blue-600' %>
                     <%= button_to 'Remove',
                       product_path(product),
                       method: :delete,
                       class: 'bg-red-600 text-white font-bold py-2 px-6 rounded-full hover:bg-red-500',
                       form: { data: { turbo_confirm: 'Are you sure?' } } %>
                   </div>
+>>>>>>> 3c63a37 (Added Pry to gem file)
                 </td>
               </tr>
             <% end %>

--- a/app/views/products/partials/_products_table.html.erb
+++ b/app/views/products/partials/_products_table.html.erb
@@ -53,13 +53,6 @@
                 <td class="text-sm text-gray-900 font-normal px-2 py-4 whitespace-nowrap ">
                   <%= product.stock %>
                 </td>
-<<<<<<< HEAD
-                <td class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap ">
-                    <%= link_to "Show this product", product, class: "bg-blue-600 hover:bg-blue-400 text-white font-bold py-2 px-4 rounded-full" %>
-                </td>
-                <td scope="col" class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap">
-                    <%= button_to 'Remove', product_path(product), method: :delete, class: 'bg-red-600 hover:bg-red-500 text-white font-bold py-2 px-4 rounded-full', form: { data: { turbo_confirm: 'Are you sure?' } } %>
-=======
                 <td class=" text-center text-sm text-gray-900 font-normal py-4 max-w-[100px]">
                   <div class="flex justify-center space-x-2">
                     <%= link_to 'Edit',
@@ -74,7 +67,6 @@
                       class: 'bg-red-600 text-white font-bold py-2 px-6 rounded-full hover:bg-red-500',
                       form: { data: { turbo_confirm: 'Are you sure?' } } %>
                   </div>
->>>>>>> 3c63a37 (Added Pry to gem file)
                 </td>
               </tr>
             <% end %>

--- a/app/views/resupplies/_header.html.erb
+++ b/app/views/resupplies/_header.html.erb
@@ -1,0 +1,17 @@
+<div class="px-2 w-full">
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Resupplies</h1>
+    <div class="flex">
+      <div class="px-3">
+       <% if can? :create, Product %>
+        <%= link_to 'New product',new_product_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+       <% end %>
+      </div>
+      <div class="px-4">
+        <% if can? :create, Resupply %>
+          <%= link_to 'Add resupply',new_resupply_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+        <% end %>
+      </div>
+    </div>    
+  </div>
+</div>

--- a/app/views/resupplies/_resupply.html.erb
+++ b/app/views/resupplies/_resupply.html.erb
@@ -1,0 +1,19 @@
+<div>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Name:</strong>
+    <%= resupply.quantity %>
+  </p>
+  <p class="my-5">
+    <strong class="block font-medium mb-1">Code:</strong>
+    <%= product.comment %>
+  </p>
+  <% if action_name != "show" %>
+    <%= link_to "Show this product", product, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <% if can? :update, Product %>
+      <%= link_to 'Edit this product',
+        edit_product_path(product),
+        class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <% end %>
+    <hr class="mt-6">
+  <% end %>
+</div>

--- a/app/views/resupplies/_table_resupplies.html.erb
+++ b/app/views/resupplies/_table_resupplies.html.erb
@@ -1,0 +1,53 @@
+<div class="px-2 w-full">
+  <div class="col-span-full xl:col-span-6 bg-white shadow-lg rounded-sm border border-gray-200">
+    <div class="p-3">
+      <!-- Table -->
+      <div class="overflow-x-auto">
+        <table class="table-auto w-full">
+          <!-- Table header -->
+          <thead class="text-xs font-semibold uppercase text-gray-400 bg-gray-50">
+            <tr>
+              <th class="p-2 whitespace-nowrap">
+                <div class="font-bold text-left">Code </div>
+              </th>
+              <th class="p-2 whitespace-nowrap">
+                <div class="font-bold text-left">Resupplies</div>
+              </th>
+              <th class="p-2 whitespace-nowrap">
+                <div class="font-bold text-left">Resupplie ID</div>
+              </th>
+              <th class="p-2 whitespace-nowrap">
+                <div class="font-bold text-center">Created at</div>
+              </th>
+              <th class="p-2 whitespace-nowrap">
+                <div class="font-bold text-center">Description</div>
+              </th>
+            </tr>
+          </thead>
+          <!-- Table body -->
+          <tbody>
+              <tr class="border-b">
+               <% @resupplies.each do |resupply| %>
+                <td class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap uppercase">
+                <%= resupply.product_id %>
+                </td>
+                <td class="text-sm text-gray-900 font-semibold px-6 py-4 whitespace-nowrap">
+                 <%= resupply.quantity %>
+                 </td>
+                <td class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap uppercase">
+                <%= resupply.id %>
+                </td>
+                <td class="text-sm text-gray-900 font-normal px-6 py-4 whitespace-nowrap ">
+                <%= resupply.created_at %>
+                </td>
+                <td class="text-sm text-gray-900 font-medium px-6 py-4 whitespace-nowrap">
+                <%= resupply.comment %>
+                </td>               
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/resupplies/index.html.erb
+++ b/app/views/resupplies/index.html.erb
@@ -1,0 +1,16 @@
+<div class="h-screen bg-gray-100 ">
+  <%= render 'dashboard/nav' %>
+  <div class="flex flex-row flex-wrap flex-1 flex-grow content-start pl-16">
+    <div class="mx-auto md:w-2/3 w-full py-5">
+      <% if notice.present? %>
+        <p class="py-2 px-3 bg-green-50 mb-5  text-green-500 font-medium rounded-lg inline-block text-center" id="notice"><%= notice %></p>
+      <% end %>
+    </div>
+    <div class="mx-auto md:w-2/3 w-full py-10">
+      <%= render 'header' %>
+    </div>
+    <div class="mx-auto md:w-2/3 w-full py-10">
+      <%= render 'table_resupplies' %>
+    </div>
+  </div>
+</div>

--- a/app/views/resupplies/index.html.erb
+++ b/app/views/resupplies/index.html.erb
@@ -1,5 +1,5 @@
 <div class="h-screen bg-gray-100 ">
-  <%= render 'dashboard/nav' %>
+  <%= render 'dashboard/sidebar' %>
   <div class="flex flex-row flex-wrap flex-1 flex-grow content-start pl-16">
     <div class="mx-auto md:w-2/3 w-full py-5">
       <% if notice.present? %>

--- a/app/views/resupplies/new.html.erb
+++ b/app/views/resupplies/new.html.erb
@@ -1,5 +1,5 @@
 <div class="h-screen bg-gray-100 ">
-  <%= render 'dashboard/nav' %>
+  <%= render 'dashboard/sidebar' %>
   <div class="flex flex-row flex-wrap flex-1 flex-grow content-start pl-16">
     <div class="mx-auto md:w-2/3 w-full pt-5 ">
       <div class="relative bg-white shadow-lg border border-gray-200 sm:p-6 rounded-sm overflow-hidden mb-8">

--- a/app/views/resupplies/new.html.erb
+++ b/app/views/resupplies/new.html.erb
@@ -1,0 +1,31 @@
+<div class="h-screen bg-gray-100 ">
+  <%= render 'dashboard/nav' %>
+  <div class="flex flex-row flex-wrap flex-1 flex-grow content-start pl-16">
+    <div class="mx-auto md:w-2/3 w-full pt-5 ">
+      <div class="relative bg-white shadow-lg border border-gray-200 sm:p-6 rounded-sm overflow-hidden mb-8">
+        <div class="relative">
+          <h1 class="text-2xl md:text-3xl text-gray-800 font-bold mb-1">New Resupply 👋</h1>
+        </div>
+      </div>
+    <div class="mx-auto md:w-2/3 w-full py-00">
+      <%= form_with model: @resupply, method: :post do |form| %>   
+      <% if $product_url == nil%>
+        <%= form.label :product_id, "Id" %>
+        <%= form.text_field :product_id,value:$product_url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+      <% else %>
+        <%= form.text_field :product_id,value:$product_url, class: "hidden block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+      <% end %>
+        <%= form.label :quantity, "Quantity" %>
+        <%= form.number_field :quantity, class: 'block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full' %>
+        <div class="my-5">
+          <%= form.label :comment %>
+          <%= form.text_field :comment, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+        </div>
+        <%= form.submit "Confirm resupply", data: { turbo: false } ,class:"rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium"%>
+      <% end %>
+      <div class="py-3 w-44">
+      <%= link_to 'Back to resupply', resupplies_path,class: "rounded-lg py-3 px-5 bg-blue-600  text-white block font-medium"%>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/resupplies/show.html.erb
+++ b/app/views/resupplies/show.html.erb
@@ -1,0 +1,18 @@
+<div class="h-screen bg-gray-100 ">
+  <%= render 'dashboard/nav' %>
+  <div class="flex flex-row flex-wrap flex-1 flex-grow content-start pl-16">
+    <div class="mx-auto md:w-2/3 w-full pt-5 ">
+      <div class="relative bg-white shadow-lg border border-gray-200 sm:p-6 rounded-sm overflow-hidden mb-8">
+        <div class="relative">
+          <h1 class="text-2xl md:text-3xl text-gray-800 font-bold mb-1">Resupplies </h1>
+        </div>
+        <% if notice.present? %>
+          <p class="py-2 px-3  bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice">
+            <%= notice %>
+          </p>
+        <% end %>
+         <%= render 'resupply' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,52 +1,55 @@
 Rails.application.routes.draw do
-  resources :clients, except: [:show]
-  resources :sales
-  resources :products, path: '/inventory/products', except: [:show]
-  resources :expenses
-  resources :users, only: %i[show edit update]
-  resource :inventory
-  resources :register
-  resources :financial_statement
-  resource :business
-  devise_for :user, controllers: { omniauth_callbacks: 'omniauth', registrations: 'users/registrations' }
-
-  # Business
-  get '/business/employees',
-      to: 'businesses#index_employees', as: 'employees'
-
-  get '/business/employees/new',
-      to: 'businesses#new_employee', as: 'new_employee'
-
-  # Business
-  post '/switch_to_own_business',
-       to: 'businesses#switch_to_own_business'
-
-  # Business enrollment
-  post '/create_and_enroll_employee',
-       to: 'business_enrollments#create_and_enroll_employee'
-
-  post '/enroll_existing_user_to_current_business',
-       to: 'business_enrollments#enroll_existing_user_to_current_business'
-
-  post '/join_to_enrolled_business',
-       to: 'business_enrollments#join_to_enrolled_business'
-
-  delete '/remove_employee_from_current_business',
-         to: 'business_enrollments#remove_employee_from_current_business'
-
-  # Sales
-  get '/search_products', to: 'sales#search_products'
-  post '/add_product_to_sale', to: 'sales#add_product_to_sale'
-  delete '/remove_product_to_sale', to: 'sales#remove_product_from_sale'
-  get '/sales/:id/details_pdf', to: 'sales#sale_details_pdf', as: 'sale_details_pdf'
-
-  # Register
-  get 'register/index'
-
-  # Financial Statement
-  get 'financial_statement/index'
-
-  # Dashboard & landing
-  get 'dashboard', to: 'dashboard#index'
-  root 'landing#index'
-end
+     resources :clients, except: [:show]
+     resources :sales
+     resources :products, path: '/inventory/products' 
+     resources :resupplies
+     resources :expenses
+     resources :users, only: %i[show edit update]
+     resource :inventory
+     resources :register
+     resources :financial_statement
+     resource :business
+     devise_for :user, controllers: { omniauth_callbacks: 'omniauth', registrations: 'users/registrations' }
+   
+     # Business
+     get '/business/employees',
+         to: 'businesses#index_employees', as: 'employees'
+   
+     get '/business/employees/new',
+         to: 'businesses#new_employee', as: 'new_employee'
+   
+     # Business
+     post '/switch_to_own_business',
+          to: 'businesses#switch_to_own_business'
+   
+     # Business enrollment
+     post '/create_and_enroll_employee',
+          to: 'business_enrollments#create_and_enroll_employee'
+   
+     post '/enroll_existing_user_to_current_business',
+          to: 'business_enrollments#enroll_existing_user_to_current_business'
+   
+     post '/join_to_enrolled_business',
+          to: 'business_enrollments#join_to_enrolled_business'
+   
+     delete '/remove_employee_from_current_business',
+            to: 'business_enrollments#remove_employee_from_current_business'
+   
+     # Sales
+     get '/search_products', to: 'sales#search_products'
+     post '/add_product_to_sale', to: 'sales#add_product_to_sale'
+     delete '/remove_product_to_sale', to: 'sales#remove_product_from_sale'
+     get '/sales/:id/details_pdf', to: 'sales#sale_details_pdf', as: 'sale_details_pdf'
+   
+     # Register
+     get 'register/index'
+   
+     # Financial Statement
+     get 'financial_statement/index'
+     get 'products/new_resupply', to: 'products#new'
+   
+     # Dashboard & landing
+     get 'dashboard', to: 'dashboard#index'
+     root 'landing#index'
+   end
+      

--- a/db/migrate/20220804220239_create_resupplies.rb
+++ b/db/migrate/20220804220239_create_resupplies.rb
@@ -1,0 +1,11 @@
+class CreateResupplies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :resupplies do |t|
+      t.references :product, null: false, foreign_key: true
+      t.integer :quantity
+      t.text :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220809233039_create_product_resupplies.rb
+++ b/db/migrate/20220809233039_create_product_resupplies.rb
@@ -1,0 +1,8 @@
+class CreateProductResupplies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :product_resupplies do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_09_212638) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_09_233039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,9 +58,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_09_212638) do
     t.string "name"
     t.string "business_type"
     t.string "address"
+    t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "description"
     t.index ["country_id"], name: "index_businesses_on_country_id"
     t.index ["owner_id"], name: "index_businesses_on_owner_id"
   end
@@ -94,6 +94,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_09_212638) do
     t.index ["business_id"], name: "index_expenses_on_business_id"
   end
 
+  create_table "product_resupplies", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "product_sales", force: :cascade do |t|
     t.bigint "product_id"
     t.bigint "sale_id"
@@ -124,6 +129,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_09_212638) do
     t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_purchases_on_product_id"
     t.index ["spent_id"], name: "index_purchases_on_spent_id"
+  end
+
+  create_table "resupplies", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.integer "quantity"
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_resupplies_on_product_id"
   end
 
   create_table "sales", force: :cascade do |t|
@@ -162,5 +176,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_09_212638) do
   add_foreign_key "clients", "businesses"
   add_foreign_key "expenses", "businesses"
   add_foreign_key "products", "businesses"
+  add_foreign_key "resupplies", "products"
   add_foreign_key "sales", "clients"
 end


### PR DESCRIPTION
# Description
What did you implemented/Why did you implemented this:
 -  Added resupplies functionality.
 -  An user can now add more stock to a product.
 - Can add resupply with product id if not given.
 - Added Pry gem to gemfile.
 - Created models for Resupply and Product resupply
 - A product can now have many resupplies.
 - Style in tailwind for resupply form.

  
  ## Screenshots 
![Screenshot_20220810_005828](https://user-images.githubusercontent.com/69171039/184182816-8dabe64b-9eaa-4b1f-8bb6-9a813fc4ae58.png)
![Screenshot_20220810_005848](https://user-images.githubusercontent.com/69171039/184182857-eb421b9f-8712-48f2-a82b-a980c31c95ca.png)
![image](https://user-images.githubusercontent.com/69171039/184185862-2bebf5c8-5928-4935-afb7-095c5360ced9.png)

![Screenshot_20220811_132648](https://user-images.githubusercontent.com/69171039/184182883-39abcd2d-80f8-4b60-9646-59225e0e37cd.png)